### PR TITLE
!skの実装

### DIFF
--- a/config/config-default.toml
+++ b/config/config-default.toml
@@ -133,3 +133,7 @@ resultNotFound = '検索結果に表示するものが無いロボ'
 invalidPageId = '無効なページ番号ロボ。最大ページ数は<%= maxPage %>ロボよ'
 list = "検索結果ロボよー (<%= currentPage %>/<%= maxPage %>):\n<%= results %>"
 haveToSpecifyKeyword = '検索キーワードを指定するロボ'
+
+[message.sk.set]
+set = 'skを設定したロボ: <%= sk %>'
+invalidCommand = '変なコマンドロボね…'

--- a/src/features/play-music/add-interactor.ts
+++ b/src/features/play-music/add-interactor.ts
@@ -14,38 +14,6 @@ type SearchResultType =
 	| { kind: 'albums'; value: Album[] }
 	| { kind: 'undefined' }
 
-function parseIndexes(strings: string[], min: number, max: number): number[] {
-	let ret: number[] = []
-
-	for (const str of strings) {
-		const match = /(\d+)(?:-|\.\.)(\d+)/.exec(str)
-		if (match) {
-			const start = parseInt(match[1], 10)
-			const end = parseInt(match[2], 10)
-
-			if (!(start < end)) {
-				throw new Error('invalid expression')
-			}
-
-			ret = [...ret, ...lodash.range(start, end + 1)]
-			continue
-		}
-
-		const index = parseInt(str, 10)
-		if (isNaN(index)) {
-			throw new Error(`failed to parse ${str} as int`)
-		}
-
-		ret.push(index)
-	}
-
-	if (!ret.every((v) => min <= v && v <= max)) {
-		throw new Error('out of range')
-	}
-
-	return ret
-}
-
 export class AddInteractor {
 	private gc: FeatureGlobalConfig
 	private searchResult: SearchResultType = { kind: 'undefined' }
@@ -93,7 +61,7 @@ export class AddInteractor {
 
 		if (sr.kind !== 'undefined') {
 			const res = lodash.flatten(
-				parseIndexes(indexes, 0, sr.value.length).map((i) => sr.value[i].select())
+				utils.parseIndexes(indexes, 0, sr.value.length).map((i) => sr.value[i].select())
 			)
 
 			if (res.every((x) => x !== undefined)) {
@@ -165,7 +133,7 @@ export class AddInteractor {
 		}
 
 		const addedMusics: Music[] = []
-		for (const i of parseIndexes(indexes, 0, this.searchResult.value.length)) {
+		for (const i of utils.parseIndexes(indexes, 0, this.searchResult.value.length)) {
 			const music = this.searchResult.value[i]
 			addedMusics.push(music)
 			this.playlist.addMusic(music)

--- a/src/features/sk/index.ts
+++ b/src/features/sk/index.ts
@@ -43,7 +43,9 @@ export class FeatureSk extends CommonFeatureBase {
 	}
 
 	initImpl(): Promise<void> {
-		this.storageDriver.setChannelStorageConstructor(() => new StorageType(new Map<string, any>([['sk', new Map<number, string[]>()]])))
+		this.storageDriver.setChannelStorageConstructor(() =>
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			new StorageType(new Map<string, any>([['sk', new Map<number, string[]>()]])))
 		this.featureCommand.registerCommand(new SetSkCommand(this.setCmdName, this.storageDriver))
 		return Promise.resolve()
 	}

--- a/src/features/sk/index.ts
+++ b/src/features/sk/index.ts
@@ -1,0 +1,71 @@
+import * as discordjs from 'discord.js'
+
+import { Command } from 'Src/features/command'
+import CommonFeatureBase from 'Src/features/common-feature-base'
+import { StorageType, StorageDriver } from '../storage'
+import * as utils from 'Src/utils'
+
+class SetSkCommand implements Command {
+	constructor(private readonly cmdName: string, private readonly storageDriver: StorageDriver) { }
+
+	name(): string {
+		return this.cmdName
+	}
+
+	description(): string {
+		return '!sk の内容を設定'
+	}
+
+	async command(msg: discordjs.Message, args: string[]): Promise<void> {
+		if (args.length < 2) {
+			await msg.reply('引数の数isダメ')
+			return
+		}
+		const nb = parseInt(args[0], 10)
+		if (isNaN(nb)) {
+			await msg.reply('第一引数が数じゃない')
+			return
+		}
+
+		const map = this.storageDriver.channel(msg).get<Map<number, string[]>>('sk')
+		const skmsgs = args.splice(1)
+		map.set(nb, skmsgs)
+		await msg.reply('skを設定したよ: ' + skmsgs.join(','))
+	}
+}
+
+export class FeatureSk extends CommonFeatureBase {
+	private skRegExp: RegExp
+
+	constructor(private readonly skCmdName: string, private readonly setCmdName: string) {
+		super()
+		this.skRegExp = new RegExp(`${skCmdName}(\\d+)`, 'g')
+	}
+
+	initImpl(): Promise<void> {
+		this.storageDriver.setChannelStorageConstructor(() => new StorageType(new Map<string, any>([['sk', new Map<number, string[]>()]])))
+		this.featureCommand.registerCommand(new SetSkCommand(this.setCmdName, this.storageDriver))
+		return Promise.resolve()
+	}
+
+	async onMessageImpl(msg: discordjs.Message): Promise<void> {
+		if (msg.content.includes(this.skCmdName)) {
+			const picked = new Map<number, string>()
+
+			await msg.reply(msg.content.replace(this.skRegExp, (match, strnb) => {
+				const nb = parseInt(strnb, 10)
+				let res = picked.get(nb)
+				if (res === undefined) {
+					res = match
+					const map = this.storageDriver.channel(msg).get<Map<number, string[]>>('sk')
+					const arr = map.get(nb)
+					if (arr !== undefined) {
+						res = utils.randomPick(arr)
+						picked.set(nb, res)
+					}
+				}
+				return res
+			}))
+		}
+	}
+}

--- a/src/features/sk/index.ts
+++ b/src/features/sk/index.ts
@@ -21,15 +21,14 @@ class SetSkCommand implements Command {
 			await msg.reply('引数の数isダメ')
 			return
 		}
-		const nb = parseInt(args[0], 10)
-		if (isNaN(nb)) {
-			await msg.reply('第一引数が数じゃない')
-			return
-		}
 
-		const map = this.storageDriver.channel(msg).get<Map<number, string[]>>('sk')
+		const nbs = utils.parseIndexes(args[0].split(','), 1, 256)
+
 		const skmsgs = args.splice(1)
-		map.set(nb, skmsgs)
+		for (const nb of nbs) {
+			const map = this.storageDriver.channel(msg).get<Map<number, string[]>>('sk')
+			map.set(nb, skmsgs)
+		}
 		await msg.reply('skを設定したよ: ' + skmsgs.join(','))
 	}
 }

--- a/src/features/sk/index.ts
+++ b/src/features/sk/index.ts
@@ -63,8 +63,8 @@ export class FeatureSk extends CommonFeatureBase {
 	initImpl(): Promise<void> {
 		this.storageDriver.setChannelStorageConstructor(
 			() =>
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				new StorageType(
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					new Map<string, any>([['sk', new Map<number, SkStore>()]])
 				)
 		)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -334,3 +334,35 @@ export async function retry<T>(func: () => Promise<T>, ntimes: number, logging =
 
 	throw new RetryError(lastError)
 }
+
+export function parseIndexes(strings: string[], min: number, max: number): number[] {
+	let ret: number[] = []
+
+	for (const str of strings) {
+		const match = /(\d+)(?:-|\.\.)(\d+)/.exec(str)
+		if (match) {
+			const start = parseInt(match[1], 10)
+			const end = parseInt(match[2], 10)
+
+			if (!(start < end)) {
+				throw new Error('invalid expression')
+			}
+
+			ret = [...ret, ...lodash.range(start, end + 1)]
+			continue
+		}
+
+		const index = parseInt(str, 10)
+		if (isNaN(index)) {
+			throw new Error(`failed to parse ${str} as int`)
+		}
+
+		ret.push(index)
+	}
+
+	if (!ret.every((v) => min <= v && v <= max)) {
+		throw new Error('out of range')
+	}
+
+	return ret
+}


### PR DESCRIPTION
元ネタはこれ
https://w.atwiki.jp/openj3/pages/401.html

# 仕様
※ `!setsk` と `!sk` のコマンド名はカスタマイズ可能

## 使用例
```
user: !setsk 1 ココア チノ リゼ
user: !setsk 2 千夜 シャロ
user: !setsk 3 寝る 遊ぶ ご飯を食べる
user: !sk1と!sk2が一緒に!sk3
bot: チノと千夜が一緒に遊ぶ
```

## `!setsk`
`!setsk <番号指定> <メッセージ1> [メッセージ2...]`
`番号指定` は1~256の整数。`n1,n2,n3` や `from..to` のように一括指定することも出来る。
`メッセージ` は抽選に出現するテキスト。`message:weight` のようにすると出現率を調整出来る。weightは正の実数で、指定しないと1と同じ扱い。指定すると、そのmessageが1よりweight倍出現しやすくなる。
このコマンドの効果はチャンネル毎に保存される。botを終了すると効果は失われる。

## `!sk`
送信するメッセージの任意の位置に`!skN` (Nは整数)を含めると、それを `!setsk` で指定されたメッセージに置き換えてbotが再送信する。
`!sk1!sk1` のように同じNの `!sk` を何度も指定すると、それぞれ同じ結果に置換される。
Nに対して `!setsk` されていなければ、その `!skN` は置換されない。